### PR TITLE
fix: add PAD token

### DIFF
--- a/ichigo-quantizer/data/dataset.py
+++ b/ichigo-quantizer/data/dataset.py
@@ -187,8 +187,11 @@ class WhisperDataset(Dataset):
             if samples.abs().max() > 0:
                 samples = samples / samples.abs().max()
 
-            # Pad audio
-            samples = self.pad_audio(samples)
+            if len(samples) > self.max_audio_length:
+                samples = samples[: self.max_audio_length]
+
+            # # Pad audio
+            # samples = self.pad_audio(samples)
 
             if samples.abs().max() > 0:
                 samples = samples / samples.abs().max()
@@ -228,13 +231,13 @@ class WhisperDataset(Dataset):
             if samples.abs().max() > 0:
                 samples = samples / samples.abs().max()
 
-            # Pad audio
-            samples = self.pad_audio(samples)
-
             # Create mask for attention
             mask = torch.zeros(30 * 16000 // 320, dtype=torch.bool)
             audio_frames = min(len(samples), self.max_audio_length) // 320
             mask[:audio_frames] = 1
+
+            # Pad audio
+            samples = self.pad_audio(samples)
 
             # Process text tokens
             tokens = list(
@@ -291,13 +294,13 @@ class WhisperDataset(Dataset):
         concatenated_audio = torch.cat(audio_samples)
         concatenated_text = " ".join(texts)
 
-        # Pad if necessary
-        concatenated_audio = self.pad_audio(concatenated_audio)
-
         # Create mask for attention
         mask = torch.zeros(30 * 16000 // 320, dtype=torch.bool)
         audio_frames = min(len(concatenated_audio), self.max_audio_length) // 320
         mask[:audio_frames] = 1
+
+        # Pad if necessary
+        concatenated_audio = self.pad_audio(concatenated_audio)
 
         # Process text tokens
         tokens = list(

--- a/ichigo-quantizer/data/hf.py
+++ b/ichigo-quantizer/data/hf.py
@@ -1,11 +1,11 @@
 from huggingface_hub import HfApi, hf_hub_download
 
 
-def download_hf(repo_id, file_name, local_dir=None):
+def download_hf(file_name, repo_id="jan-hq/ichigo-quantizer", local_dir="checkpoints"):
     hf_hub_download(repo_id=repo_id, filename=file_name, local_dir=local_dir)
 
 
-def upload_hf(repo_id, folder_path, commit_message):
+def upload_hf(folder_path, commit_message, repo_id="jan-hq/ichigo-quantizer"):
     api = HfApi()
     api.create_repo(repo_id=repo_id, exist_ok=True)
     api.upload_folder(

--- a/ichigo-quantizer/scripts/test.sh
+++ b/ichigo-quantizer/scripts/test.sh
@@ -1,7 +1,15 @@
 WANDB_ENTITY="janai" CUDA_VISIBLE_DEVICES=0 python -m scripts.test \
-    --model-path "checkpoints/loss=0.19.ckpt" \
-    --test-data "linhtran92/viet_bud500" \
+    --model-path "checkpoints/epoch_accuracy=0.86387.ckpt" \
+    --test-data "capleaf/viVoice" \
     --model-size "medium-vi-2d-2048c-dim64" \
     --whisper-name "medium" \
     --language "vi" \
+    --batch-size 1
+
+WANDB_ENTITY="janai" CUDA_VISIBLE_DEVICES=1 python -m scripts.test \
+    --model-path "checkpoints/epoch_accuracy=0.86387.ckpt" \
+    --test-data "parler-tts/libritts_r_filtered" \
+    --model-size "medium-vi-2d-2048c-dim64" \
+    --whisper-name "medium" \
+    --language "en" \
     --batch-size 1


### PR DESCRIPTION
# Bug: Incorrect Mask Generation After Audio Padding

## Description
During code review, we discovered that the mask generation after audio padding is incorrectly implemented. The current code creates masks with all 1s for padded audio. Given the padded audio with the padding value = 0:
```
Input Audio: [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]
```

```python
# Current problematic code
concatenated_audio = self.pad_audio(concatenated_audio)
mask = torch.zeros(30 * 16000 // 320, dtype=torch.bool)
audio_frames = min(len(concatenated_audio), self.max_audio_length) // 320
mask[:audio_frames] = 1  # Bug: This includes padding tokens
```
- The training code reserves a special VQ token for padding (vq_codes + 1).
- However, with mask=1 everywhere, ~mask becomes all zeros:
   So instead of creating a mask: ```Expected Mask: [1, 1, 1, 1, 1, 0, 0, 0, 0, 0] ```, author created a buggy mask: ```[1, 1, 1, 1, 1, 1, 1, 1, 1, 1] ```
- Result: The special padding embedding is never applied cause ~mask will be all 0s.
```python
# Impact on training
if self.training and self.config.mask_embs and mask is not None:
    x[~mask] = project_out(self.rq.layers[0]._codebook.embed[0, self.vq_codes])
```

## Impact
- The padding tokens is not trained.
- Model sees raw embeddings in padding regions instead of consistent padding tokens. Leading to longer semantic token sequence with fixed length = 750 when encode audio.